### PR TITLE
🔀 :: 445 repository의 save 메서드 호출 시 성능 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## How to clone?
 
 ```
-   https://github.com/GSM-MSG/Bitgouel-Server.git
+https://github.com/GSM-MSG/Bitgouel-Server.git
 ```
 
 ## Contributing

--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
@@ -15,7 +15,7 @@ class StudentUtil(
 
     fun createStudent(user: User, club: Club, grade: Int, classRoom: Int, number: Int, admissionNumber: Int) {
         val student = Student(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club,
             grade = grade,

--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/UserUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/UserUtil.kt
@@ -211,7 +211,7 @@ class UserUtil(
             throw AlreadyExistPhoneNumberException("이미 가입된 전화번호를 기입하였습니다. info : [ phoneNumber = $phoneNumber ]")
 
         return User(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             email = email,
             name = name,
             phoneNumber = phoneNumber,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -29,6 +29,8 @@ import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
+import team.msg.domain.student.enums.StudentRole
+import team.msg.domain.student.model.Student
 import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
@@ -79,9 +81,8 @@ class AuthServiceImpl(
 
         val club = queryClub(request.highSchool, request.clubName)
 
-<<<<<<< Updated upstream
         studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber)
-=======
+
         val student = Student(
             id = UUID(0, 0),
             user = user,
@@ -94,7 +95,6 @@ class AuthServiceImpl(
             studentRole = StudentRole.STUDENT
         )
         studentRepository.save(student)
->>>>>>> Stashed changes
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -29,9 +29,6 @@ import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
-import team.msg.domain.student.enums.StudentRole
-import team.msg.domain.student.model.Student
-import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
 import team.msg.domain.user.enums.Authority
@@ -49,7 +46,6 @@ class AuthServiceImpl(
     private val userRepository: UserRepository,
     private val securityUtil: SecurityUtil,
     private val clubRepository: ClubRepository,
-    private val studentRepository: StudentRepository,
     private val schoolRepository: SchoolRepository,
     private val teacherRepository: TeacherRepository,
     private val professorRepository: ProfessorRepository,
@@ -82,19 +78,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber)
-
-        val student = Student(
-            id = UUID(0, 0),
-            user = user,
-            club = club,
-            grade = request.grade,
-            classRoom = request.classRoom,
-            number = request.number,
-            cohort = request.admissionNumber - 2020,
-            credit = 0,
-            studentRole = StudentRole.STUDENT
-        )
-        studentRepository.save(student)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -79,7 +79,22 @@ class AuthServiceImpl(
 
         val club = queryClub(request.highSchool, request.clubName)
 
+<<<<<<< Updated upstream
         studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber)
+=======
+        val student = Student(
+            id = UUID(0, 0),
+            user = user,
+            club = club,
+            grade = request.grade,
+            classRoom = request.classRoom,
+            number = request.number,
+            cohort = request.admissionNumber - 2020,
+            credit = 0,
+            studentRole = StudentRole.STUDENT
+        )
+        studentRepository.save(student)
+>>>>>>> Stashed changes
     }
 
     /**
@@ -99,7 +114,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val teacher = Teacher(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club
         )
@@ -123,7 +138,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val bbozzak = Bbozzak(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club
         )
@@ -148,7 +163,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val professor = Professor(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club,
             university = request.university
@@ -173,7 +188,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val government = Government(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club,
             governmentName = request.governmentName,
@@ -200,7 +215,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val companyInstructor = CompanyInstructor(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             club = club,
             company = request.company

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -65,7 +65,7 @@ class CertificationServiceImpl(
         }
 
         val certification = Certification(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             studentId = student.id,
             name = request.name,
             acquisitionDate = request.acquisitionDate

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -39,7 +39,7 @@ class InquiryServiceImpl(
         val currentUser = userUtil.queryCurrentUser()
 
         val inquiry = Inquiry(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = currentUser,
             question = request.question,
             questionDetail = request.questionDetail,
@@ -170,7 +170,7 @@ class InquiryServiceImpl(
         val inquiry = inquiryRepository findById id
 
         val inquiryAnswer = InquiryAnswer(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             answer = request.answer,
             admin = currentUser,
             inquiryId = inquiry.id

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -69,7 +69,7 @@ class LectureServiceImpl(
         val credit = if(request.lectureType != "상호학점인정교육과정") 0 else request.credit
 
         val lecture = Lecture(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             user = user,
             name = request.name,
             semester = request.semester,
@@ -90,7 +90,7 @@ class LectureServiceImpl(
 
         val lectureDates = request.lectureDates.map {
             LectureDate(
-                id = UUID.randomUUID(),
+                id = UUID(0, 0),
                 lecture = savedLecture,
                 completeDate = it.completeDate,
                 startTime = it.startTime,
@@ -217,7 +217,7 @@ class LectureServiceImpl(
             throw OverMaxRegisteredUserException("수강 인원이 가득 찼습니다. info : [ maxRegisteredUser = ${lecture.maxRegisteredUser}, currentSignUpLectureStudent = $registeredLectureCount ]")
 
         val registeredLecture = RegisteredLecture(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             student = student,
             lecture = lecture
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -42,7 +42,7 @@ class PostServiceImpl(
 
         val post = request.run {
             Post(
-                id = UUID.randomUUID(),
+                id = UUID(0, 0),
                 userId = user.id,
                 title = title,
                 content = content,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -51,7 +51,7 @@ class StudentActivityServiceImpl(
         val teacher = teacherRepository findByClub student.club
 
         val studentActivity = StudentActivity(
-            id = UUID.randomUUID(),
+            id = UUID(0, 0),
             title = request.title,
             content = request.content,
             credit = request.credit,

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
@@ -86,7 +86,6 @@ class AuthServiceImplTest : BehaviorSpec({
         userRepository,
         securityUtil,
         clubRepository,
-        studentRepository,
         schoolRepository,
         teacherRepository,
         professorRepository,

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -1,14 +1,12 @@
 package team.msg.common.entity
 
-import org.hibernate.annotations.GenericGenerator
+import javax.persistence.Column
+import javax.persistence.Id
+import javax.persistence.MappedSuperclass
 import org.hibernate.proxy.HibernateProxy
 import org.springframework.data.domain.Persistable
 import team.msg.common.ulid.ULIDGenerator
 import java.util.*
-import javax.persistence.Column
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
 abstract class BaseUUIDEntity(

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -14,8 +14,6 @@ import javax.persistence.MappedSuperclass
 abstract class BaseUUIDEntity(
 
     @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     @get:JvmName(name = "getIdentifier")
     open var id: UUID = UUID(0, 0)


### PR DESCRIPTION
## 💡 배경 및 개요

JPA repository의 save 메서드 호출 시 해당 데이터가 존재하는지 확인하는 Select 쿼리를 발생시키지 않도록 하기 위해 Persistable의 isNew와 getId 메서드를 재정의했음에도 select쿼리가 발생했습니다

Resolves: #445 

## 📃 작업내용

id (Primary Key) 자동 생성 전략 삭제

기존에 엔티티 새로 생성 시 UUID.random()으로 설정해 놓은 것을 UUID(0, 0) (초기값을 가리키는 값)으로 삽입하도록 변경하였습니다
## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
