### PR TITLE
# 452 FAQ 작성 Request Dto 필드 길이 설정

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/web/CreateFaqWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/web/CreateFaqWebRequest.kt
@@ -1,11 +1,14 @@
 package team.msg.domain.faq.presentation.web
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class CreateFaqWebRequest(
     @field:NotBlank
+    @field:Size(max=100)
     val question: String,
 
     @field:NotBlank
+    @field:Size(max=3000)
     val answer: String
 )

--- a/bitgouel-api/src/main/resources/logback-spring.xml
+++ b/bitgouel-api/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<configuration scan="true" scanPeriod="30 seconds">
+<configuration scan="true" scanPeriod="1 minute">
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
     <springProfile name="local | prod">


### PR DESCRIPTION
## 💡 배경 및 개요

FAQ 작성 Request Dto 필드 길이 설정

Resolves: #{452}

## 📃 작업내용

제목은 100자, 내용은 넉넉잡아 3000자로 설정했습니다.
logback 스캔 주기 1분으로 늘렸습니다.