### PR TITLE
강의 상세조회에 user id 값 추가

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -65,6 +65,7 @@ data class LectureResponse(
             maxRegisteredUser = lecture.maxRegisteredUser,
             isRegistered = isRegistered,
             lecturer = lecture.instructor,
+            userId = lecture.user.id,
             credit = lecture.credit,
             essentialComplete = lecture.essentialComplete
         )
@@ -152,6 +153,7 @@ data class LectureDetailsResponse(
     val headCount: Int,
     val maxRegisteredUser: Int,
     val isRegistered: Boolean,
+    val userId: UUID,
     val lecturer: String,
     val credit: Int,
     val essentialComplete: Boolean

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -293,6 +293,10 @@ class LectureServiceImplTest : BehaviorSpec({
         val lectureId = UUID.randomUUID()
         val name = "name"
         val content = "content"
+        val instructorUserId = UUID.randomUUID()
+        val instructorUser = fixture<User> {
+            property(User::id) { instructorUserId }
+        }
         val instructor = "instructor"
         val headCount = 0
         val maxRegisteredUser = 5
@@ -326,6 +330,7 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Lecture::startDate) { startDate }
             property(Lecture::endDate) { endDate }
             property(Lecture::instructor) { instructor }
+            property(Lecture::user) { instructorUser }
             property(Lecture::credit) { credit }
             property(Lecture::semester) { semester }
             property(Lecture::division) { division }
@@ -351,6 +356,7 @@ class LectureServiceImplTest : BehaviorSpec({
             property(LectureDetailsResponse::endDate) { endDate }
             property(LectureDetailsResponse::lectureDates) { lectureDateResponses }
             property(LectureDetailsResponse::lecturer) { instructor }
+            property(LectureDetailsResponse::userId) { instructorUserId }
             property(LectureDetailsResponse::lectureStatus) { lectureStatus }
             property(LectureDetailsResponse::isRegistered) { isRegistered }
             property(LectureDetailsResponse::createAt) { lecture.createdAt }


### PR DESCRIPTION
## 💡 배경 및 개요

강의 상세조회 api에 강사의 유저 id 값을 추가했습니다.

Resolves: #474 

## 📃 작업내용

- 강의 상세조회 api response에 강사 유저 id값을 추가했습니다.
- 그에 맞춰 테스트 코드도 수정해주었습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?