### PR TITLE
삭제된 강의 데이터가 강의 리스트에서 조회되던 문제 해결

### DIFF
--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
@@ -27,7 +27,8 @@ class CustomLectureRepositoryImpl(
         ).from(lecture)
             .leftJoin(registeredLecture).on(lecture.eq(registeredLecture.lecture))
             .where(
-                eqLectureType(lectureType)
+                eqLectureType(lectureType),
+                eqIsDeleted(false)
             )
             .groupBy(lecture)
             .offset(pageable.offset)
@@ -58,7 +59,8 @@ class CustomLectureRepositoryImpl(
             .from(lecture)
             .where(
                 lecture.division.contains(division),
-                eqLine(keyword)
+                eqLine(keyword),
+                eqIsDeleted(false)
             )
             .fetch()
             .distinct()
@@ -67,7 +69,10 @@ class CustomLectureRepositoryImpl(
         queryFactory
             .select(lecture.department)
             .from(lecture)
-            .where(eqDepartment(keyword))
+            .where(
+                eqDepartment(keyword),
+                eqIsDeleted(false)
+            )
             .fetch()
             .distinct()
 
@@ -75,7 +80,10 @@ class CustomLectureRepositoryImpl(
         queryFactory
             .select(lecture.division)
             .from(lecture)
-            .where(eqDivision(keyword))
+            .where(
+                eqDivision(keyword),
+                eqIsDeleted(false)
+            )
             .fetch()
             .distinct()
 


### PR DESCRIPTION
## 💡 배경 및 개요

삭제된 강의 데이터가 강의 리스트에서 조회되던 문제를 해결했습니다.

Resolves: #48 

## 📃 작업내용

custom repo에서 isDelete 조건을 추가해주지 않아 생긴 문제였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
