### PR TITLE
강사 조회 안되는 버그 수정

### DIFF
--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
@@ -3,9 +3,12 @@ package team.msg.domain.user.repository.custom.impl
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import team.msg.common.enums.ApproveStatus
+import team.msg.domain.company.model.QCompany.company
 import team.msg.domain.company.model.QCompanyInstructor.companyInstructor
+import team.msg.domain.government.model.QGovernment.government
 import team.msg.domain.government.model.QGovernmentInstructor.governmentInstructor
 import team.msg.domain.university.model.QProfessor.professor
+import team.msg.domain.university.model.QUniversity.university
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.QUser.user
 import team.msg.domain.user.model.User
@@ -61,12 +64,14 @@ class CustomUserRepositoryImpl(
         queryFactory.select(user, professor.university.name, companyInstructor.company.name, governmentInstructor.government.name)
             .from(user)
             .leftJoin(professor).on(user.eq(professor.user))
+            .leftJoin(professor.university, university)
             .leftJoin(companyInstructor).on(user.eq(companyInstructor.user))
+            .leftJoin(companyInstructor.company, company)
             .leftJoin(governmentInstructor).on(user.eq(governmentInstructor.user))
+            .leftJoin(governmentInstructor.government, government)
             .where(
                 user.authority.`in`(Authority.ROLE_PROFESSOR, Authority.ROLE_COMPANY_INSTRUCTOR, Authority.ROLE_GOVERNMENT),
-                nameLike(keyword)
-                    ?.or(organizationNameLike(keyword))
+                nameLike(keyword)?.or(organizationNameLike(keyword))
             )
             .fetch()
             .map { tuple ->


### PR DESCRIPTION
## 💡 배경 및 개요

강사가 조회되지 않는 버그를 고쳤습니다.

Resolves: #500 

## 📃 작업내용

강사 권한 별 기관 엔티티와 강사 엔티티가 나뉘어 중간 join문이 없어 생기던 버그였습니다. 
join 해주어 고쳤습니다!

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
