### PR TITLE
# 501 가입 당시 학년 정보 추가

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
@@ -13,7 +13,7 @@ class StudentUtil(
     private val studentRepository: StudentRepository
 ) {
 
-    fun createStudent(user: User, club: Club, grade: Int, classRoom: Int, number: Int, admissionNumber: Int) {
+    fun createStudent(user: User, club: Club, grade: Int, classRoom: Int, number: Int, admissionNumber: Int, subscriptionGrade: Int) {
         val student = Student(
             id = UUID(0, 0),
             user = user,
@@ -23,6 +23,7 @@ class StudentUtil(
             number = number,
             cohort = admissionNumber - 2020,
             credit = 0,
+            subscriptionGrade = subscriptionGrade,
             studentRole = StudentRole.STUDENT
         )
         studentRepository.save(student)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -18,7 +18,6 @@ import team.msg.domain.user.exception.InvalidPasswordException
 import team.msg.domain.user.exception.InvalidPhoneNumberException
 import team.msg.domain.user.exception.UserAlreadyApprovedException
 import team.msg.domain.user.model.User
-import team.msg.domain.user.presentation.data.response.AdminUserResponse
 import team.msg.domain.user.presentation.data.response.UserResponse
 import team.msg.domain.user.presentation.data.response.UsersResponse
 import team.msg.domain.user.repository.UserRepository

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -44,7 +44,7 @@ class AdminServiceImpl(
 
         return UsersResponse(
             users.map { user ->
-                val student = studentRepository.findByUser(user) ?: null
+                val student = studentRepository.findByUser(user)
                 UserResponse.of(user, student)
             }
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
@@ -1,8 +1,22 @@
 package team.msg.domain.auth.mapper
 
 import org.springframework.stereotype.Component
-import team.msg.domain.auth.presentation.data.request.*
-import team.msg.domain.auth.presentation.data.web.*
+import team.msg.domain.auth.presentation.data.request.BbozzakSignUpRequest
+import team.msg.domain.auth.presentation.data.request.ChangePasswordRequest
+import team.msg.domain.auth.presentation.data.request.CompanyInstructorSignUpRequest
+import team.msg.domain.auth.presentation.data.request.GovernmentSignUpRequest
+import team.msg.domain.auth.presentation.data.request.LoginRequest
+import team.msg.domain.auth.presentation.data.request.ProfessorSignUpRequest
+import team.msg.domain.auth.presentation.data.request.StudentSignUpRequest
+import team.msg.domain.auth.presentation.data.request.TeacherSignUpRequest
+import team.msg.domain.auth.presentation.data.web.BbozzakSignUpWebRequest
+import team.msg.domain.auth.presentation.data.web.ChangePasswordWebRequest
+import team.msg.domain.auth.presentation.data.web.CompanyInstructorSignUpWebRequest
+import team.msg.domain.auth.presentation.data.web.GovernmentSignUpWebRequest
+import team.msg.domain.auth.presentation.data.web.LoginWebRequest
+import team.msg.domain.auth.presentation.data.web.ProfessorSignUpWebRequest
+import team.msg.domain.auth.presentation.data.web.StudentSignUpWebRequest
+import team.msg.domain.auth.presentation.data.web.TeacherSignUpWebRequest
 
 @Component
 class AuthRequestMapperImpl : AuthRequestMapper {
@@ -17,7 +31,8 @@ class AuthRequestMapperImpl : AuthRequestMapper {
             grade = webRequest.grade,
             clubName = webRequest.clubName,
             number = webRequest.number,
-            admissionNumber = webRequest.admissionNumber
+            admissionNumber = webRequest.admissionNumber,
+            subscriptionGrade = webRequest.subscriptionGrade
         )
 
     override fun teacherSignUpWebRequestToDto(webRequest: TeacherSignUpWebRequest): TeacherSignUpRequest =

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/StudentSignUpRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/StudentSignUpRequest.kt
@@ -10,5 +10,6 @@ data class StudentSignUpRequest(
     val grade: Int,
     val classRoom: Int,
     val number: Int,
-    val admissionNumber: Int
+    val admissionNumber: Int,
+    val subscriptionGrade: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/StudentSignUpWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/StudentSignUpWebRequest.kt
@@ -40,5 +40,8 @@ data class StudentSignUpWebRequest(
     val number: Int,
 
     @field:NotNull
-    val admissionNumber: Int
+    val admissionNumber: Int,
+
+    @field:NotNull
+    val subscriptionGrade: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -85,7 +85,7 @@ class AuthServiceImpl(
 
         val club = queryClub(request.highSchool, request.clubName)
 
-        studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber)
+        studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber, request.subscriptionGrade)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -352,6 +352,7 @@ class LectureServiceImpl(
             number = student.number,
             cohort = student.cohort,
             credit = student.credit + lecture.credit,
+            subscriptionGrade = student.subscriptionGrade,
             studentRole = student.studentRole
         )
 
@@ -387,6 +388,7 @@ class LectureServiceImpl(
             number = student.number,
             cohort = student.cohort,
             credit = student.credit - lecture.credit,
+            subscriptionGrade = student.subscriptionGrade,
             studentRole = student.studentRole
         )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.user.presentation.data.response
 
 import team.msg.common.enums.ApproveStatus
+import team.msg.domain.student.model.Student
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
 import java.util.*
@@ -22,19 +23,15 @@ data class UserResponse (
             organization = organization
         )
 
-        fun of(user: User) = AdminUserResponse(
+        fun of(user: User, student: Student?) = AdminUserResponse(
             id = user.id,
             name = user.name,
             authority = user.authority,
             approveStatus = user.approveStatus,
             phoneNumber = user.phoneNumber,
+            subscriptionYear = user.createdAt.year,
+            subscriptionGrade = student?.subscriptionGrade,
             email = user.email
-        )
-
-        fun listOf(users: List<User>) = UsersResponse(
-            users.map {
-                of(it)
-            }
         )
 
         fun detailOf(user: User) = UserDetailsResponse(
@@ -61,6 +58,8 @@ data class AdminUserResponse(
     val authority: Authority,
     val approveStatus: ApproveStatus,
     val phoneNumber: String,
+    val subscriptionYear: Int,
+    val subscriptionGrade: Int?,
     val email: String
 )
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -11,6 +11,8 @@ import team.msg.common.util.StudentUtil
 import team.msg.common.util.UserUtil
 import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.club.repository.ClubRepository
+import team.msg.domain.student.model.Student
+import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.exception.UserAlreadyApprovedException
 import team.msg.domain.user.model.User
@@ -27,11 +29,13 @@ class AdminServiceImplTest : BehaviorSpec({
     val userUtil = mockk<UserUtil>()
     val studentUtil = mockk<StudentUtil>()
     val clubRepository = mockk<ClubRepository>()
+    val studentRepository = mockk<StudentRepository>()
     val adminServiceImpl = AdminServiceImpl(
         userRepository = userRepository,
         userUtil = userUtil,
         studentUtil = studentUtil,
-        clubRepository = clubRepository
+        clubRepository = clubRepository,
+        studentRepository = studentRepository
     )
 
     // queryUsers 테스트 코드
@@ -48,6 +52,11 @@ class AdminServiceImplTest : BehaviorSpec({
             property(User::phoneNumber) { "01012345678" }
             property(User::authority) { authority }
             property(User::approveStatus) { approveStatus }
+        }
+
+        val student = fixture<Student> {
+            property(Student::id) { UUID.randomUUID() }
+            property(Student::user) { user }
         }
 
         val request = fixture<QueryUsersRequest> {
@@ -70,6 +79,7 @@ class AdminServiceImplTest : BehaviorSpec({
         }
 
         every { userRepository.query(keyword, authority, approveStatus) } returns listOf(user)
+        every { studentRepository.findByUser(any()) } returns student
 
         When("User 리스트 요청 시") {
             val result = adminServiceImpl.queryUsers(request)

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
@@ -128,6 +128,7 @@ class AuthServiceImplTest : BehaviorSpec({
         every { schoolRepository.findByName(request.highSchool) } returns school
         every { clubRepository.findByNameAndSchool(request.clubName, school) } returns club
         every { securityUtil.passwordEncode(any()) } returns encodedPassword
+        every { studentUtil.createStudent(any(), any(), any(), any(), any(), any(), any()) } returns Unit
         every { studentRepository.save(any()) } returns student
 
         When("학생 회원가입 요청을 하면") {

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/certification/service/CertificationServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/certification/service/CertificationServiceImplTest.kt
@@ -67,6 +67,7 @@ class CertificationServiceImplTest : BehaviorSpec ({
 
         every { userUtil.queryCurrentUser() } returns user
         every { studentRepository.findByUser(user) } returns student
+        every { certificationRepository.findAllByStudentId(student.id) } returns listOf(certification)
         every { certificationRepository.save(any()) } returns certification
 
         When("자격증 등록 요청을 하면") {

--- a/bitgouel-batch/src/main/kotlin/team/msg/jobs/student/GraduateStudentJobConfiguration.kt
+++ b/bitgouel-batch/src/main/kotlin/team/msg/jobs/student/GraduateStudentJobConfiguration.kt
@@ -182,6 +182,7 @@ class GraduateStudentJobConfiguration(
                 number = number,
                 cohort = cohort,
                 credit = credit,
+                subscriptionGrade = subscriptionGrade,
                 studentRole = StudentRole.GRADUATE
             )
         }
@@ -198,6 +199,7 @@ class GraduateStudentJobConfiguration(
                 number = number,
                 cohort = cohort,
                 credit = credit,
+                subscriptionGrade = subscriptionGrade,
                 studentRole = StudentRole.STUDENT
             )
         }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -1,18 +1,11 @@
 package team.msg.domain.student.model
 
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.FetchType
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
-import javax.persistence.OneToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.domain.club.model.Club
 import team.msg.domain.student.enums.StudentRole
 import team.msg.domain.user.model.User
 import java.util.*
+import javax.persistence.*
 
 @Entity
 class Student(
@@ -28,23 +21,26 @@ class Student(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club,
 
-    @Column(columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    @Column(name = "grade", columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val grade: Int,
 
     @Column(name = "class_room", columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val classRoom: Int,
 
-    @Column(columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    @Column(name = "number", columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val number: Int,
 
-    @Column(columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    @Column(name = "cohort", columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val cohort: Int,
 
-    @Column(columnDefinition = "INT", nullable = false)
+    @Column(name = "credit", columnDefinition = "INT", nullable = false)
     val credit: Int,
 
+    @Column(name = "subscription_grade", columnDefinition = "INT", nullable = false)
+    val subscriptionGrade: Int,
+
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    @Column(name = "student_role", columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
 ) : BaseUUIDEntity(id)


### PR DESCRIPTION
## 💡 배경 및 개요

가입 당시 학년 정보 추가

Resolves: #501

## 📃 작업내용

유저 전체 조회 API에서 가입 당시 학년 정보를 추가로 반환해줍니다. 학생이 아닌 유저의 경우 null을 반환합니다.