### PR TITLE
515 동아리 생성 및 동아리 이름 전체 조회 개발

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/AlreadyExistClubException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/AlreadyExistClubException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.club.exception
+
+import team.msg.domain.club.exception.constant.ClubErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class AlreadyExistClubException(
+    message: String
+) : BitgouelException(message, ClubErrorCode.ALREADY_EXIST_CLUB.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/constant/ClubErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/constant/ClubErrorCode.kt
@@ -4,5 +4,6 @@ enum class ClubErrorCode(
     val status: Int
 ) {
     NOT_EMPTY_CLUB(400),
-    CLUB_NOT_FOUND(404)
+    CLUB_NOT_FOUND(404),
+    ALREADY_EXIST_CLUB(409)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -1,16 +1,18 @@
 package team.msg.domain.club.presentation
 
-import javax.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import team.msg.domain.club.mapper.ClubRequestMapper
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.presentation.data.response.ClubNamesResponse
 import team.msg.domain.club.presentation.data.response.ClubsResponse
+import team.msg.domain.club.presentation.web.request.CreateClubWebRequest
 import team.msg.domain.club.presentation.web.request.UpdateClubWebRequest
 import team.msg.domain.club.service.ClubService
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
 import java.util.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/club")
@@ -48,9 +50,17 @@ class ClubController(
         return ResponseEntity.ok(response)
     }
 
+    @PostMapping("/{school_id}")
+    fun createClub(@PathVariable("school_id") schoolId: Long, @RequestBody @Valid webRequest: CreateClubWebRequest): ResponseEntity<Unit> {
+        val request = clubRequestMapper.createClubWebRequestToDto(webRequest)
+        clubService.createClub(schoolId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
     @PatchMapping("/{id}")
     fun updateClub(@PathVariable id: Long, @RequestBody @Valid webRequest: UpdateClubWebRequest): ResponseEntity<Unit> {
-        clubService.updateClub(id, clubRequestMapper.updateClubWebRequestToDto(webRequest))
+        val request = clubRequestMapper.updateClubWebRequestToDto(webRequest)
+        clubService.updateClub(id, request)
         return ResponseEntity.noContent().build()
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import team.msg.domain.club.mapper.ClubRequestMapper
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
+import team.msg.domain.club.presentation.data.response.ClubNamesResponse
 import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.presentation.web.request.UpdateClubWebRequest
 import team.msg.domain.club.service.ClubService
@@ -20,6 +21,12 @@ class ClubController(
     @GetMapping
     fun queryAllClubs(@RequestParam("highSchool") highSchool: String): ResponseEntity<ClubsResponse> {
         val response = clubService.queryAllClubs(highSchool)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/name")
+    fun queryAllClubs(@RequestParam("schoolName") schoolName: String?): ResponseEntity<ClubNamesResponse> {
+        val response = clubService.queryAllClubNames(schoolName)
         return ResponseEntity.ok(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -27,7 +27,7 @@ class ClubController(
     }
 
     @GetMapping("/name")
-    fun queryAllClubs(@RequestParam("schoolName") schoolName: String?): ResponseEntity<ClubNamesResponse> {
+    fun queryAllClubNames(@RequestParam("schoolName") schoolName: String?): ResponseEntity<ClubNamesResponse> {
         val response = clubService.queryAllClubNames(schoolName)
         return ResponseEntity.ok(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -21,6 +21,12 @@ data class ClubResponse(
             )
         }
 
+        fun nameListOf(clubs: List<String>): List<ClubNameResponse> = clubs.map {
+            ClubNameResponse(
+                name = it
+            )
+        }
+
         fun detailOf(club: Club, students: List<Student>, teacher: Teacher?) = ClubDetailsResponse(
             clubId = club.id,
             clubName = club.name,
@@ -60,4 +66,12 @@ data class SchoolToClubResponse(
     val id: Long,
     val name: String,
     val field: Field
+)
+
+data class ClubNameResponse(
+    val name: String
+)
+
+data class ClubNamesResponse(
+    val clubs: List<ClubNameResponse>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.club.service
 
+import team.msg.domain.club.presentation.data.reqeust.CreateClubRequest
 import team.msg.domain.club.presentation.data.reqeust.UpdateClubRequest
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.presentation.data.response.ClubNamesResponse
@@ -13,6 +14,7 @@ interface ClubService {
     fun queryClubDetailsById(id: Long): ClubDetailsResponse
     fun queryMyClubDetails(): ClubDetailsResponse
     fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse
+    fun createClub(schoolId: Long, request: CreateClubRequest)
     fun updateClub(id: Long, request: UpdateClubRequest)
     fun deleteClub(id: Long)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -2,12 +2,14 @@ package team.msg.domain.club.service
 
 import team.msg.domain.club.presentation.data.reqeust.UpdateClubRequest
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
+import team.msg.domain.club.presentation.data.response.ClubNamesResponse
 import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
 import java.util.*
 
 interface ClubService {
     fun queryAllClubs(highSchool: String): ClubsResponse
+    fun queryAllClubNames(schoolName: String?): ClubNamesResponse
     fun queryClubDetailsById(id: Long): ClubDetailsResponse
     fun queryMyClubDetails(): ClubDetailsResponse
     fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -69,6 +69,22 @@ class ClubServiceImpl(
     }
 
     /**
+     * 모든 동아리 이름을 조회하는 비즈니스 로직
+     * @param 동아리 이름을 조회하기 위한 학교 id
+     * @return 동아리 이름 리스트
+     */
+    @Transactional(readOnly = true)
+    override fun queryAllClubNames(schoolName: String?): ClubNamesResponse {
+        val clubs = clubRepository.findAllBySchoolName(schoolName)
+
+        val response = ClubNamesResponse(
+            ClubResponse.nameListOf(clubs)
+        )
+
+        return response
+    }
+
+    /**
      * 동아리를 상세 조회하는 비즈니스 로직
      * @param 동아리를 상세 조회하기 위한 id
      * @return 동아리 상세 정보를 담은 dto

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/mapper/SchoolRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/mapper/SchoolRequestMapperImpl.kt
@@ -8,16 +8,13 @@ import team.msg.domain.school.presentation.web.CreateSchoolWebRequest
 import team.msg.domain.school.presentation.web.UpdateSchoolWebRequest
 
 @Component
-class SchoolRequestMapperImpl(
-    private val clubRequestMapper: ClubRequestMapper
-) : SchoolRequestMapper {
+class SchoolRequestMapperImpl : SchoolRequestMapper {
 
     override fun createSchoolWebRequestToDto(webRequest: CreateSchoolWebRequest): CreateSchoolRequest =
         CreateSchoolRequest(
             schoolName = webRequest.schoolName,
             line = webRequest.line,
-            departments = webRequest.departments,
-            club = webRequest.club.map { clubRequestMapper.createClubWebRequestToDto(it) }
+            departments = webRequest.departments
         )
 
     override fun updateSchoolWebRequestToDto(webRequest: UpdateSchoolWebRequest): UpdateSchoolRequest =

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/request/CreateSchoolRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/request/CreateSchoolRequest.kt
@@ -1,11 +1,9 @@
 package team.msg.domain.school.presentation.data.request
 
 import team.msg.common.enums.Line
-import team.msg.domain.club.presentation.data.reqeust.CreateClubRequest
 
 data class CreateSchoolRequest(
     val schoolName: String,
     val line: Line,
-    val departments: List<String>,
-    val club: List<CreateClubRequest>
+    val departments: List<String>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/web/CreateSchoolWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/web/CreateSchoolWebRequest.kt
@@ -1,10 +1,9 @@
 package team.msg.domain.school.presentation.web
 
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotNull
 import team.msg.common.enums.Line
 import team.msg.common.validation.NotBlankStringList
-import team.msg.domain.club.presentation.web.request.CreateClubWebRequest
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 data class CreateSchoolWebRequest(
 
@@ -15,8 +14,6 @@ data class CreateSchoolWebRequest(
     val line: Line,
 
     @field:NotBlankStringList
-    val departments: List<String>,
-
-    val club: List<CreateClubWebRequest>
+    val departments: List<String>
 
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
@@ -92,16 +92,7 @@ class SchoolServiceImpl(
             departments = request.departments
         )
 
-        val clubs = request.club.map { club ->
-            Club(
-                school = school,
-                name = club.clubName,
-                field = club.field
-            )
-        }
-
         schoolRepository.save(school)
-        clubRepository.saveAll(clubs)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -69,6 +69,7 @@ class SecurityConfig(
 
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/club/name").permitAll()
             .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -73,6 +73,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.POST, "/club/{school_id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.PATCH, "/club/{id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.DELETE, "/club/{id}").hasRole(ADMIN)
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
@@ -17,4 +17,6 @@ interface ClubRepository : JpaRepository<Club, Long>, CustomClubRepository {
     fun findAllBySchool(school: School): List<Club>
 
     fun existsBySchool(school: School): Boolean
+
+    fun existsByName(name: String): Boolean
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/CustomClubRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/CustomClubRepository.kt
@@ -3,4 +3,5 @@ package team.msg.domain.club.repository.custom
 interface CustomClubRepository {
     fun existsOne(id: Long): Boolean
     fun deleteAllBySchoolId(schoolId: Long)
+    fun findAllBySchoolName(schoolName: String?): List<String>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/impl/CustomClubRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/impl/CustomClubRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.club.repository.custom.impl
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import team.msg.domain.club.model.QClub.club
 import team.msg.domain.club.repository.custom.CustomClubRepository
@@ -23,5 +24,16 @@ class CustomClubRepositoryImpl(
             .where(club.school.id.eq(schoolId))
             .execute()
     }
+
+    override fun findAllBySchoolName(schoolName: String?): List<String> =
+        queryFactory
+            .select(club.name)
+            .from(club)
+            .where(schoolNameEq(schoolName))
+            .orderBy(club.school.name.asc(), club.name.asc())
+            .fetch()
+
+    private fun schoolNameEq(schoolName: String?): BooleanExpression? =
+        if (schoolName == null) null else club.school.name.eq(schoolName)
 
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/impl/CustomClubRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/custom/impl/CustomClubRepositoryImpl.kt
@@ -34,6 +34,6 @@ class CustomClubRepositoryImpl(
             .fetch()
 
     private fun schoolNameEq(schoolName: String?): BooleanExpression? =
-        if (schoolName == null) null else club.school.name.eq(schoolName)
+        if (schoolName.isNullOrBlank()) null else club.school.name.eq(schoolName)
 
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/custom/CustomSchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/custom/CustomSchoolRepository.kt
@@ -1,5 +1,5 @@
 package team.msg.domain.school.repository.custom
 
 interface CustomSchoolRepository {
-    fun existsOne(id: Long): Boolean
+    fun existsOne(id: Long): Booleanz
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/custom/CustomSchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/custom/CustomSchoolRepository.kt
@@ -1,5 +1,5 @@
 package team.msg.domain.school.repository.custom
 
 interface CustomSchoolRepository {
-    fun existsOne(id: Long): Booleanz
+    fun existsOne(id: Long): Boolean
 }


### PR DESCRIPTION
## 💡 배경 및 개요

동아리 생성 및 동아리 이름 전체 조회 개발

Resolves: #515

## 📃 작업내용

동아리 수정에 없던 동아리 존재여부 유효성 검사를 추가했습니다.
동아리 이름 전체 조회 개발했습니다. 정렬은 학교 이름과 동아리 이름을 오름차순으로 정렬했습니다. 이 기능은 회원가입 시 사용되는 기능이기에 permitAll()로 설정했습니다.
학교를 생성하며 같이 생성하던 동아리를 따로 동아리 생성 기능으로 빼서 개발했습니다.