### PR TITLE
강의 이수 API 변경사항 적용

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -109,12 +109,15 @@ class LectureController(
         return ResponseEntity.ok(response)
     }
 
-    @PatchMapping("/{id}/{student_id}")
-    fun updateLectureCompleteStatus(
-        @PathVariable id: UUID, @PathVariable("student_id") studentId: UUID,
-        @RequestParam isComplete: Boolean
-    ): ResponseEntity<Unit> {
-        lectureService.updateLectureCompleteStatus(id, studentId, isComplete)
+    @GetMapping("/student/{id}/{student_id}")
+    fun querySignedUpStudentDetails(@PathVariable id: UUID, @PathVariable("student_id") studentId: UUID): ResponseEntity<SignedUpStudentDetailsResponse> {
+        val response = lectureService.querySignedUpStudentDetails(id, studentId)
+        return ResponseEntity.ok(response)
+    }
+
+    @PatchMapping("/{id}/complete")
+    fun updateLectureCompleteStatus(@PathVariable id: UUID, @RequestParam studentIds: List<UUID>): ResponseEntity<Unit> {
+        lectureService.updateLectureCompleteStatus(id, studentIds)
         return ResponseEntity.noContent().build()
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -113,6 +113,20 @@ data class LectureResponse(
             lectures = lectures
         )
 
+        fun signedUpDetailOf(student: Student, completeStatus: CompleteStatus, currentCompletedDate: LocalDate?) = SignedUpStudentDetailsResponse(
+            email = student.user!!.email,
+            name = student.user!!.name,
+            grade = student.grade,
+            classNumber = student.number,
+            number = student.number,
+            phoneNumber = student.user!!.phoneNumber,
+            school = student.club.school.name,
+            clubName = student.club.name,
+            cohort = student.cohort,
+            currentCompletedDate = currentCompletedDate,
+            completeStatus = completeStatus
+        )
+
         fun of(student: Student, isComplete: Boolean) = student.run {
             SignedUpStudentResponse(
                 id = id,
@@ -229,7 +243,7 @@ data class SignedUpStudentDetailsResponse(
     val school: String,
     val clubName: String,
     val cohort: Int,
-    val currentCompletedDate: LocalDate,
+    val currentCompletedDate: LocalDate?,
     val completeStatus: CompleteStatus
 )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.lecture.presentation.data.response
 import org.springframework.data.domain.Page
+import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.model.Lecture
@@ -99,13 +100,13 @@ data class LectureResponse(
             departments = departments
         )
         
-        fun of(lecture: Lecture, isComplete: Boolean, currentCompletedDate: LocalDate?) = SignedUpLectureResponse(
+        fun of(lecture: Lecture, completeStatus: CompleteStatus, currentCompletedDate: LocalDate?) = SignedUpLectureResponse(
             id = lecture.id,
             name = lecture.name,
             lectureType = lecture.lectureType,
             currentCompletedDate = currentCompletedDate,
             lecturer = lecture.instructor,
-            isComplete = isComplete
+            completeStatus = completeStatus
         )
 
         fun signedUpOf(lectures: List<SignedUpLectureResponse>) = SignedUpLecturesResponse(
@@ -115,15 +116,12 @@ data class LectureResponse(
         fun of(student: Student, isComplete: Boolean) = student.run {
             SignedUpStudentResponse(
                 id = id,
-                email = user!!.email,
                 name = user!!.name,
                 grade = grade,
                 classNumber = classRoom,
                 number = number,
-                phoneNumber = user!!.phoneNumber,
                 school = club.school.name,
                 clubName = club.name,
-                cohort = cohort,
                 isComplete = isComplete
             )
         }
@@ -203,7 +201,7 @@ data class SignedUpLectureResponse(
     val lectureType: String,
     val currentCompletedDate: LocalDate?,
     val lecturer: String,
-    val isComplete: Boolean
+    val completeStatus: CompleteStatus
 )
 
 data class SignedUpStudentsResponse(
@@ -212,6 +210,16 @@ data class SignedUpStudentsResponse(
 
 data class SignedUpStudentResponse(
     val id: UUID,
+    val name: String,
+    val grade: Int,
+    val classNumber: Int,
+    val number: Int,
+    val school: String,
+    val clubName: String,
+    val isComplete: Boolean
+)
+
+data class SignedUpStudentDetailsResponse(
     val email: String,
     val name: String,
     val grade: Int,
@@ -221,7 +229,8 @@ data class SignedUpStudentResponse(
     val school: String,
     val clubName: String,
     val cohort: Int,
-    val isComplete: Boolean
+    val currentCompletedDate: LocalDate,
+    val completeStatus: CompleteStatus
 )
 
 data class DivisionsResponse(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -15,6 +15,7 @@ import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
 import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.LinesResponse
+import team.msg.domain.lecture.presentation.data.response.SignedUpStudentDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.SignedUpStudentsResponse
 import java.util.UUID
 
@@ -32,6 +33,7 @@ interface LectureService {
     fun queryInstructors(keyword: String): InstructorsResponse
     fun queryAllSignedUpLectures(studentId: UUID): SignedUpLecturesResponse
     fun queryAllSignedUpStudents(id: UUID): SignedUpStudentsResponse
-    fun updateLectureCompleteStatus(id: UUID, studentId: UUID, isComplete: Boolean)
+    fun querySignedUpStudentDetails(id: UUID, studentId: UUID): SignedUpStudentDetailsResponse
+    fun updateLectureCompleteStatus(id: UUID, studentIds: List<UUID>)
     fun lectureReceiptStatusExcel(response: HttpServletResponse)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -43,6 +43,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletResponse
 import team.msg.common.util.KakaoUtil
+import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.model.LectureLocation
 import team.msg.domain.lecture.repository.LectureLocationRepository
@@ -442,7 +443,7 @@ class LectureServiceImpl(
         val signedUpLectures = registeredLectureRepository.findLecturesAndIsCompleteByStudentId(studentId)
             .map {
                 val lecture = it.lecture
-                val isComplete = it.isComplete
+                val isComplete = it.registeredLecture.completeStatus
 
                 lectureDateRepository.findByCurrentCompletedDate(lecture.id)
                     .let { currentCompletedDate -> LectureResponse.of(lecture, isComplete, currentCompletedDate) }
@@ -483,9 +484,31 @@ class LectureServiceImpl(
                     throw ForbiddenSignedUpLectureException("학생의 수강 이력을 볼 권한이 없습니다. info : [ userId = ${user.id} ]")
                 registeredLectureRepository.findSignedUpStudentsByLectureId(id)
             }
-        }.map { LectureResponse.of(it.student, it.isComplete) }
+        }.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
 
         val response = LectureResponse.signedUpOf(students)
+
+        return response
+    }
+
+    /**
+     * 강의에 신청한 학생의 상세정보를 조회하는 비지니스 로직입니다.
+     *
+     * 기업 강사, 유관기관 강사, 대학 교수 -> 자기 강의만 조회할 수 있음 (다른 강사의 강의 학생 조회 시 예외)
+     * 뽀짝 선생님, 취업 동아리 선생님 -> 담당 동아리 소속 학생만 조회
+     * 어드민 -> 제한 없음
+     *
+     * @param 조회할 강의 id, 학생 id
+     * @return 조회한 학생 정보를 담은 dto
+     */
+    @Transactional(readOnly = true)
+    override fun querySignedUpStudentDetails(id: UUID, studentId: UUID): SignedUpStudentDetailsResponse {
+        val student = studentRepository findById studentId
+        val registeredLecture = registeredLectureRepository.findByLectureIdAndStudentId(id, studentId)
+            ?: throw UnSignedUpLectureException("학생의 강의 신청 기록을 찾을 수 없습니다. info : [ lectureId = $id, studentId = ${student.id} ]")
+        val currentCompletedDate = lectureDateRepository.findByCurrentCompletedDate(id)
+
+        val response = LectureResponse.signedUpDetailOf(student, registeredLecture.completeStatus, currentCompletedDate)
 
         return response
     }
@@ -500,43 +523,51 @@ class LectureServiceImpl(
      * @param 이수 상태를 변경할 강의 id와 학생 id, 변결될 강의 여부
      */
     @Transactional(rollbackFor = [Exception::class])
-    override fun updateLectureCompleteStatus(id: UUID, studentId: UUID, isComplete: Boolean) {
+    override fun updateLectureCompleteStatus(id: UUID, studentIds: List<UUID>) {
         val user = userUtil.queryCurrentUser()
+        val students = studentRepository.findByIdIn(studentIds)
+        val lecture = lectureRepository findById id
 
         when(user.authority) {
             Authority.ROLE_TEACHER -> {
                 val teacher = teacherRepository findByUser user
-                val student = studentRepository findById studentId
 
-                if(teacher.club != student.club)
+                if(students.any { teacher.club != it.club })
                     throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
+
             }
             Authority.ROLE_BBOZZAK -> {
                 val bbozzak = bbozzakRepository findByUser user
-                val student = studentRepository findById studentId
 
-                if(bbozzak.club != student.club)
+                if(students.any { bbozzak.club != it.club })
                     throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
             }
             Authority.ROLE_ADMIN -> { }
             else -> {
-                val lecture = lectureRepository findById id
                 if (lecture.user != user)
                     throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
             }
         }
 
-        val registeredLecture = registeredLectureRepository.findByLectureIdAndStudentId(id, studentId)
-            ?: throw UnSignedUpLectureException("학생의 강의 신청 기록을 찾을 수 없습니다. info : [ lectureId = $id, studentId = $studentId ]")
-        
-        val updatedRegisteredLecture = RegisteredLecture(
-            id = registeredLecture.id,
-            student = registeredLecture.student,
-            lecture = registeredLecture.lecture,
-            isComplete = isComplete
-        )
+        val updatedRegisteredLectures = students.map { student ->
+            val registeredLecture = registeredLectureRepository.findByStudentAndLecture(student, lecture)
+                ?: throw UnSignedUpLectureException("학생의 강의 신청 기록을 찾을 수 없습니다. info : [ lectureId = $id, studentId = ${student.id} ]")
 
-        registeredLectureRepository.save(updatedRegisteredLecture)
+            val completeStatus = when(student.grade) {
+                1 -> CompleteStatus.COMPLETED_IN_1RD
+                2 -> CompleteStatus.COMPLETED_IN_2RD
+                else -> CompleteStatus.COMPLETED_IN_3RD
+            }
+
+            RegisteredLecture(
+                id = registeredLecture.id,
+                student = registeredLecture.student,
+                lecture = registeredLecture.lecture,
+                completeStatus = completeStatus
+            )
+        }
+
+        registeredLectureRepository.saveAll(updatedRegisteredLectures)
     }
 
     @Transactional(readOnly = true, rollbackFor = [Exception::class])

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -47,6 +47,7 @@ import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.model.LectureLocation
 import team.msg.domain.lecture.repository.LectureLocationRepository
+import team.msg.domain.student.exception.InvalidStudentGradeException
 
 @Service
 class LectureServiceImpl(
@@ -556,7 +557,8 @@ class LectureServiceImpl(
             val completeStatus = when(student.grade) {
                 1 -> CompleteStatus.COMPLETED_IN_1RD
                 2 -> CompleteStatus.COMPLETED_IN_2RD
-                else -> CompleteStatus.COMPLETED_IN_3RD
+                3 -> CompleteStatus.COMPLETED_IN_3RD
+                else -> throw InvalidStudentGradeException("유효하지 않은 학년입니다. info : [ grade = ${student.grade} ]")
             }
 
             RegisteredLecture(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/InvalidStudentGradeException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/InvalidStudentGradeException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.student.exception
+
+import team.msg.domain.student.exception.constant.StudentErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class InvalidStudentGradeException(
+    message: String
+) : BitgouelException(message, StudentErrorCode.INVALID_STUDENT_GRADE.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentErrorCode.kt
@@ -3,5 +3,6 @@ package team.msg.domain.student.exception.constant
 enum class StudentErrorCode(
     val status: Int
 ) {
-    STUDENT_NOT_FOUND(404)
+    STUDENT_NOT_FOUND(404),
+    INVALID_STUDENT_GRADE(409)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -114,7 +114,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/lecture/department").hasAnyRole(ADMIN, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/{student_id}/signup").hasAnyRole(ADMIN, TEACHER, STUDENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/student/{id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
-            .mvcMatchers(HttpMethod.GET, "/lecture/{id}/{student_id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/lecture/student/{id}/{student_id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.PATCH, "/lecture/{id}/complete").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/division").hasAnyRole(ADMIN, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/excel").hasRole(ADMIN)

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -114,7 +114,8 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/lecture/department").hasAnyRole(ADMIN, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/{student_id}/signup").hasAnyRole(ADMIN, TEACHER, STUDENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/student/{id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
-            .mvcMatchers(HttpMethod.PATCH, "/lecture/{id}/{student_id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/lecture/{id}/{student_id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
+            .mvcMatchers(HttpMethod.PATCH, "/lecture/{id}/complete").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/division").hasAnyRole(ADMIN, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/excel").hasRole(ADMIN)
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -17,6 +17,7 @@ import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.model.Club
 import team.msg.domain.club.repository.ClubRepository
+import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
@@ -1029,7 +1030,11 @@ class LectureServiceImplTest : BehaviorSpec({
         val lectureType = "type"
         val lecturer = "lecturer"
 
-        val isComplete = false
+        val completeStatus = CompleteStatus.NOT_COMPLETED_YET
+
+        val registeredLecture = fixture<RegisteredLecture> {
+            property(RegisteredLecture::completeStatus) { completeStatus }
+        }
 
         val lecture = fixture<Lecture> {
             property(Lecture::id) { lectureId }
@@ -1049,11 +1054,11 @@ class LectureServiceImplTest : BehaviorSpec({
 
         val lectureAndIsCompleteData = fixture<LectureAndRegisteredProjection> {
             property(LectureAndRegisteredProjection::lecture) { lecture }
-            property(LectureAndRegisteredProjection::isComplete) { isComplete }
+            property(LectureAndRegisteredProjection::registeredLecture) { registeredLecture }
         }
         val lectureAndIsComplete = listOf(lectureAndIsCompleteData)
 
-        val lectureResponse = LectureResponse.of(lecture, isComplete, LocalDate.MAX)
+        val lectureResponse = LectureResponse.of(lecture, completeStatus, LocalDate.MAX)
         val response = LectureResponse.signedUpOf(listOf(lectureResponse))
 
         every { teacherRepository.findByUser(teacherUser) } returns teacher
@@ -1140,6 +1145,12 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Club::name) { clubBName }
         }
 
+        val completeStatus = CompleteStatus.COMPLETED_IN_1RD
+
+        val registeredLecture = fixture<RegisteredLecture> {
+            property(RegisteredLecture::completeStatus) { completeStatus }
+        }
+
         val studentId = UUID.randomUUID()
         val grade = 1
         val classRoom = 2
@@ -1154,7 +1165,7 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Student::classRoom) { classRoom }
             property(Student::number) { number }
             property(Student::cohort) { cohort }
-        }.let { SignedUpStudentProjection(it, true) }
+        }.let { SignedUpStudentProjection(it, registeredLecture) }
 
         val studentB = fixture<Student> {
             property(Student::id) { studentId }
@@ -1164,7 +1175,7 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Student::classRoom) { classRoom }
             property(Student::number) { number }
             property(Student::cohort) { cohort }
-        }.let { SignedUpStudentProjection(it, true) }
+        }.let { SignedUpStudentProjection(it, registeredLecture) }
 
         val students = listOf(studentA, studentB)
         val clubAStudents = listOf(studentA)
@@ -1209,9 +1220,9 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Lecture::user) { professorUserA }
         }
 
-        val allStudentsData = students.map { LectureResponse.of(it.student, it.isComplete) }
-        val clubAStudentsData = clubAStudents.map { LectureResponse.of(it.student, it.isComplete) }
-        val clubBStudentsData = clubBStudents.map { LectureResponse.of(it.student, it.isComplete) }
+        val allStudentsData = students.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
+        val clubAStudentsData = clubAStudents.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
+        val clubBStudentsData = clubBStudents.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
 
         val allStudentsResponse = LectureResponse.signedUpOf(allStudentsData)
         val clubAStudentsResponse = LectureResponse.signedUpOf(clubAStudentsData)
@@ -1278,7 +1289,7 @@ class LectureServiceImplTest : BehaviorSpec({
     Given("lecture id와 student id, isComplete가 주어질 때"){
         val lectureId = UUID.randomUUID()
         val studentId = UUID.randomUUID()
-        val isComplete = true
+        val studentIds = listOf(studentId)
         val schoolName = "광주소프트웨어마이스터고등학교"
 
         val school = fixture<School> {
@@ -1289,6 +1300,9 @@ class LectureServiceImplTest : BehaviorSpec({
         val clubBId = 1L
         val clubAName = "clubAName"
         val clubBName = "clubBName"
+
+        val completeStatus = CompleteStatus.NOT_COMPLETED_YET
+        val updatedCompleteStatus = CompleteStatus.NOT_COMPLETED_YET
 
         val clubA = fixture<Club> {
             property(Club::id) { clubAId }
@@ -1304,6 +1318,7 @@ class LectureServiceImplTest : BehaviorSpec({
         val student = fixture<Student> {
             property(Student::id) { studentId }
             property(Student::club) { clubA }
+            property(Student::grade) { 1 }
         }
 
         val teacherUser = fixture<User> {
@@ -1347,13 +1362,13 @@ class LectureServiceImplTest : BehaviorSpec({
         val registeredLecture = fixture<RegisteredLecture> {
             property(RegisteredLecture::lecture) { lecture }
             property(RegisteredLecture::student) { student }
-            property(RegisteredLecture::isComplete) { false }
+            property(RegisteredLecture::completeStatus) { completeStatus }
         }
 
         val updatedRegisteredLecture = fixture<RegisteredLecture> {
             property(RegisteredLecture::lecture) { lecture }
             property(RegisteredLecture::student) { student }
-            property(RegisteredLecture::isComplete) { isComplete }
+            property(RegisteredLecture::completeStatus) { CompleteStatus.COMPLETED_IN_1RD }
         }
 
         every { teacherRepository.findByUser(teacherUser) } returns teacher
@@ -1367,7 +1382,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 Bbozzak이나 Teacher이고, 학생과 같은 동아리에 소속되어있으면"){
             every { userUtil.queryCurrentUser() } returns teacherUser
 
-            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentId, isComplete)
+            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentIds)
 
             Then("registerdLecture 가 저장이 되어야 한다.") {
                 verify(exactly = 1) { registeredLectureRepository.save(any()) }
@@ -1379,7 +1394,7 @@ class LectureServiceImplTest : BehaviorSpec({
 
             Then("ForbiddenCompletedLectureException이 발생해야 한다.") {
                 shouldThrow<ForbiddenSignedUpLectureException> {
-                    lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentId, isComplete)
+                    lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentIds)
                 }
             }
         }
@@ -1387,7 +1402,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 Admin이면"){
             every { userUtil.queryCurrentUser() } returns adminUser
 
-            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentId, isComplete)
+            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentIds)
 
             Then("registerdLecture 가 저장이 되어야 한다.") {
                 verify(exactly = 1) { registeredLectureRepository.save(any()) }
@@ -1397,7 +1412,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 PROFESSOR, COMPANY_INSTRUCTOR, GOVERNMENT이고 강의 강사라면") {
             every { userUtil.queryCurrentUser() } returns professorUserA
 
-            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentId, isComplete)
+            lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentIds)
 
             Then("registerdLecture 가 저장이 되어야 한다.") {
                 verify(exactly = 1) { registeredLectureRepository.save(any()) }
@@ -1409,7 +1424,7 @@ class LectureServiceImplTest : BehaviorSpec({
 
             Then("ForbiddenCompletedLectureException이 발생해야 한다.") {
                 shouldThrow<ForbiddenSignedUpLectureException> {
-                    lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentId, isComplete)
+                    lectureServiceImpl.updateLectureCompleteStatus(lectureId, studentIds)
                 }
             }
         }

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -45,7 +45,7 @@ import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureLocationRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
-import team.msg.domain.lecture.repository.custom.projection.LectureAndIsCompleteProjection
+import team.msg.domain.lecture.repository.custom.projection.LectureAndRegisteredProjection
 import team.msg.domain.lecture.repository.custom.projection.LectureListProjection
 import team.msg.domain.lecture.repository.custom.projection.SignedUpStudentProjection
 import team.msg.domain.school.model.School
@@ -1047,9 +1047,9 @@ class LectureServiceImplTest : BehaviorSpec({
             property(LectureDate::lecture) { lecture }
         }
 
-        val lectureAndIsCompleteData = fixture<LectureAndIsCompleteProjection> {
-            property(LectureAndIsCompleteProjection::lecture) { lecture }
-            property(LectureAndIsCompleteProjection::isComplete) { isComplete }
+        val lectureAndIsCompleteData = fixture<LectureAndRegisteredProjection> {
+            property(LectureAndRegisteredProjection::lecture) { lecture }
+            property(LectureAndRegisteredProjection::isComplete) { isComplete }
         }
         val lectureAndIsComplete = listOf(lectureAndIsCompleteData)
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/CompleteStatus.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/CompleteStatus.kt
@@ -1,0 +1,10 @@
+package team.msg.domain.lecture.enums
+
+enum class CompleteStatus(
+    val description: String
+) {
+    NOT_COMPLETED_YET("아직 이수하지 않음"),
+    COMPLETED_IN_3RD("이수 완료(3학년)"),
+    COMPLETED_IN_2RD("이수 완료(2학년)"),
+    COMPLETED_IN_1RD("이수 완료(1학년)")
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -2,10 +2,13 @@ package team.msg.domain.lecture.model
 
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
+import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.student.model.Student
 import java.util.UUID
 
@@ -23,6 +26,10 @@ class RegisteredLecture(
     @JoinColumn(name = "lecture_id", columnDefinition = "BINARY(16)")
     val lecture: Lecture,
 
-    @Column(columnDefinition = "TINYINT", nullable = false)
-    val isComplete: Boolean = false
-) : BaseUUIDEntity(id)
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    val completeStatus: CompleteStatus = CompleteStatus.NOT_COMPLETED_YET
+) : BaseUUIDEntity(id) {
+
+    fun idComplete() = completeStatus != CompleteStatus.NOT_COMPLETED_YET
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
@@ -1,14 +1,14 @@
 package team.msg.domain.lecture.repository.custom
 
 import team.msg.domain.lecture.model.RegisteredLecture
-import team.msg.domain.lecture.repository.custom.projection.LectureAndIsCompleteProjection
+import team.msg.domain.lecture.repository.custom.projection.LectureAndRegisteredProjection
 import team.msg.domain.lecture.repository.custom.projection.SignedUpStudentProjection
 import java.util.*
 
 interface CustomRegisteredLectureRepository {
     fun deleteAllByStudentId(studentId: UUID)
     fun existsOne(studentId: UUID,lectureId: UUID): Boolean
-    fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<LectureAndIsCompleteProjection>
+    fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<LectureAndRegisteredProjection>
     fun findSignedUpStudentsByLectureId(lectureId: UUID): List<SignedUpStudentProjection>
     fun findSignedUpStudentsByLectureIdAndClubId(lectureId: UUID, clubId: Long): List<SignedUpStudentProjection>
     fun findByLectureIdAndStudentId(lectureId: UUID, studentId: UUID): RegisteredLecture?

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
@@ -1,18 +1,20 @@
 package team.msg.domain.lecture.repository.custom.impl
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Component
 import team.msg.domain.club.model.QClub.club
 import team.msg.domain.lecture.model.QLecture.lecture
 import team.msg.domain.lecture.model.QRegisteredLecture.registeredLecture
 import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.lecture.repository.custom.CustomRegisteredLectureRepository
-import team.msg.domain.lecture.repository.custom.projection.LectureAndIsCompleteProjection
-import team.msg.domain.lecture.repository.custom.projection.QLectureAndIsCompleteProjection
+import team.msg.domain.lecture.repository.custom.projection.LectureAndRegisteredProjection
+import team.msg.domain.lecture.repository.custom.projection.QLectureAndRegisteredProjection
 import team.msg.domain.lecture.repository.custom.projection.QSignedUpStudentProjection
 import team.msg.domain.lecture.repository.custom.projection.SignedUpStudentProjection
 import team.msg.domain.student.model.QStudent.student
 import java.util.*
 
+@Component
 class CustomRegisteredLectureRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomRegisteredLectureRepository {
@@ -34,11 +36,11 @@ class CustomRegisteredLectureRepositoryImpl(
         return fetchOne != null
     }
 
-    override fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<LectureAndIsCompleteProjection> =
+    override fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<LectureAndRegisteredProjection> =
         queryFactory.select(
-                QLectureAndIsCompleteProjection(
+                QLectureAndRegisteredProjection(
                     lecture,
-                    registeredLecture.isComplete
+                    registeredLecture
                 )
             ).from(registeredLecture)
             .leftJoin(registeredLecture.lecture, lecture)
@@ -52,7 +54,7 @@ class CustomRegisteredLectureRepositoryImpl(
         queryFactory.select(
                 QSignedUpStudentProjection(
                     student,
-                    registeredLecture.isComplete
+                    registeredLecture
                 )
             ).from(registeredLecture)
             .leftJoin(registeredLecture.lecture, lecture)
@@ -66,7 +68,7 @@ class CustomRegisteredLectureRepositoryImpl(
         queryFactory.select(
                 QSignedUpStudentProjection(
                     student,
-                    registeredLecture.isComplete
+                    registeredLecture
                 )
             ).from(registeredLecture)
             .leftJoin(registeredLecture.lecture, lecture)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/projection/LectureProjection.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/projection/LectureProjection.kt
@@ -2,6 +2,7 @@ package team.msg.domain.lecture.repository.custom.projection
 
 import com.querydsl.core.annotations.QueryProjection
 import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.student.model.Student
 
 data class LectureListProjection @QueryProjection constructor (
@@ -11,10 +12,10 @@ data class LectureListProjection @QueryProjection constructor (
 
 data class SignedUpStudentProjection @QueryProjection constructor(
     val student: Student,
-    val isComplete: Boolean
+    val registeredLecture: RegisteredLecture
 )
 
-data class LectureAndIsCompleteProjection @QueryProjection constructor(
+data class LectureAndRegisteredProjection @QueryProjection constructor(
     val lecture: Lecture,
-    val isComplete: Boolean
+    val registeredLecture: RegisteredLecture
 )

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
@@ -20,4 +20,5 @@ interface StudentRepository : CrudRepository<Student, UUID> {
     @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
     fun findAllByCohort(cohort: Int): List<Student>
     fun existsByClub(club: Club): Boolean
+    fun findByIdIn(ids: List<UUID>): List<Student>
 }


### PR DESCRIPTION
## 💡 배경 및 개요

강의 이수에서 요구하는 요구사항이 달라짐에 따라 API 로직을 변경했습니다.

Resolves: #519
 
## 📃 작업내용

https://www.notion.so/f13d8386b49e4375ac6e99b4e8943e2c?v=1b847b9c9db345f0ac2a085c69a45592&pvs=4

- 강의 신청 내역 조회 API 변경
  - response의 isComplete를 completeStatus로 변경
  
- 강의 이수 중인 학생 전체 조회 API 변경
  -  response에서 email, phoneNumber, cohort 삭제
  
- 강의 이수 중인 학생 상세 조회 API 개발

- 강의 이수 여부 변경 -> 강의 이수 완료로 목적 변경
  - studentIds로 학생 이수 여부 일괄 완료 가능하게
  - 매핑 url 변경



## 🙋‍♂️ 리뷰노트

이수한 학년을 컬럼으로 추가할까 했는데 이수하기 전엔 null로 다룬다는 점이 조심...스러워서 enum으로 다루기로 했습니다...만! 다른 좋은 조언 있으시면 해주세요 :D

추가로 테스트 코드 수정은 pr이 머지된 후 하려고 합니다. 테스트코드를 지금 수정하기엔 양이 방대해 오래걸릴 것 같고,,. 또 엑셀 작업을 하기 위해선 일단 변경사항을 반영하는게 먼저라고 생각했어요~!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
