### PR TITLE
학교 수정 시 학교 이름이 변경되지 않으면 학교 수정이 되지않는 버그를 고쳤습니다.

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
@@ -126,7 +126,7 @@ class SchoolServiceImpl(
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateSchool(id: Long, request: UpdateSchoolRequest, logoImage: MultipartFile) {
-        if (schoolRepository.existsByName(request.schoolName)) {
+        if (schoolRepository.existsByNameAndIdNotLike(request.schoolName, id)) {
             throw AlreadyExistSchoolException("이미 존재하는 학교입니다. info : [ schoolName = ${request.schoolName} ]")
         }
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
@@ -7,4 +7,5 @@ import team.msg.domain.school.repository.custom.CustomSchoolRepository
 interface SchoolRepository : CrudRepository<School, Long>, CustomSchoolRepository {
     fun findByName(name: String): School?
     fun existsByName(name: String): Boolean
+    fun existsByNameAndIdNotLike(name: String, id: Long): Boolean
 }


### PR DESCRIPTION
## 💡 배경 및 개요

기존 학교들의 이름 중복을 막기 위해 검색하는 과정에서 자신의 이름까지 중복 리스트에 포함하며 학교 수정 시 이름을 변경하지 않으면 학교 수정이 안되는 버그가 있었습니다.

자기 자신은 이름 검색에서 제외하여 해결했습니다.

Resolves: #536 

## 📃 작업내용

- 수정되는 학교 자기 자신은 학교 이름 리스트를 조회하는 데에서 제외

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
