### PR TITLE
동아리 수정 시 나타나던 버그 수정

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -184,7 +184,7 @@ class ClubServiceImpl(
         val club = clubRepository.findByIdOrNull(id)
             ?: throw ClubNotFoundException("존재하지 않는 동아리입니다. info : [ clubId = $id ]")
 
-        if (clubRepository.existsByName(request.clubName)) {
+        if (clubRepository.existsByNameAndIdNotLike(request.clubName, id)) {
             throw AlreadyExistClubException("이미 존재하는 동아리입니다. info : [ clubName = ${request.clubName} ]")
         }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -189,6 +189,7 @@ class ClubServiceImpl(
         }
 
         val updateClub = Club(
+            id = id,
             school = club.school,
             name = request.clubName,
             field = request.field

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
@@ -19,4 +19,6 @@ interface ClubRepository : JpaRepository<Club, Long>, CustomClubRepository {
     fun existsBySchool(school: School): Boolean
 
     fun existsByName(name: String): Boolean
+
+    fun existsByNameAndIdNotLike(name: String, id: Long): Boolean
 }


### PR DESCRIPTION
## 💡 배경 및 개요

동아리 수정 시 나타나던 버그를 고쳤습니다.

Resolves: #536 

## 📃 작업내용

- 동아리 수정 시 동아리 이름을 변경하지 않으면 동아리 수정 자체가 안되던 버그
  - 요청된 이름의 동아리를 검색할 때 수정 대상의 동아리를 제외하고 조회하여 해결했습니다.
  
- 동아리 수정 시 새로운 동아리로 생성되던 버그
  - id를 지정하지 않아 새로운 엔티티로 취급되어 추가로 저장되던 버그였습니다. id를 명시해 해결했습니다. 

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
