### PR TITLE
강의 신청 학생 이수 여부에 따라 필터링하여 조회

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapper.kt
@@ -5,12 +5,14 @@ import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequ
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllSignedUpStudentsRequest
 import team.msg.domain.lecture.presentation.data.request.UpdateLectureRequest
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDivisionsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
+import team.msg.domain.lecture.presentation.data.web.QueryAllSignedUpStudentsWebRequest
 import team.msg.domain.lecture.presentation.data.web.UpdateLectureWebRequest
 
 interface LectureRequestMapper {
@@ -20,4 +22,5 @@ interface LectureRequestMapper {
     fun queryAllLinesWebRequestToDto(webRequest: QueryAllLinesWebRequest): QueryAllLinesRequest
     fun queryAllDepartmentsWebRequestToDto(webRequest: QueryAllDepartmentsWebRequest): QueryAllDepartmentsRequest
     fun queryAllDivisionsWebRequestToDto(webRequest: QueryAllDivisionsWebRequest): QueryAllDivisionsRequest
+    fun queryAllSignedUpStudentsWebRequestToDto(webRequest: QueryAllSignedUpStudentsWebRequest): QueryAllSignedUpStudentsRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
@@ -7,6 +7,7 @@ import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequ
 import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllSignedUpStudentsRequest
 import team.msg.domain.lecture.presentation.data.request.UpdateLectureRequest
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.LectureDateWebRequest
@@ -14,6 +15,7 @@ import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebReque
 import team.msg.domain.lecture.presentation.data.web.QueryAllDivisionsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
+import team.msg.domain.lecture.presentation.data.web.QueryAllSignedUpStudentsWebRequest
 import team.msg.domain.lecture.presentation.data.web.UpdateLectureWebRequest
 
 @Component
@@ -77,5 +79,9 @@ class LectureRequestMapperImpl : LectureRequestMapper{
 
     override fun queryAllDivisionsWebRequestToDto(webRequest: QueryAllDivisionsWebRequest) = QueryAllDivisionsRequest(
         keyword = webRequest.keyword
+    )
+
+    override fun queryAllSignedUpStudentsWebRequestToDto(webRequest: QueryAllSignedUpStudentsWebRequest) = QueryAllSignedUpStudentsRequest(
+        isComplete = webRequest.isComplete
     )
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -104,8 +104,9 @@ class LectureController(
     }
 
     @GetMapping("/student/{id}")
-    fun queryAllSignedUpStudents(@PathVariable id: UUID): ResponseEntity<SignedUpStudentsResponse> {
-        val response = lectureService.queryAllSignedUpStudents(id)
+    fun queryAllSignedUpStudents(@PathVariable id: UUID, webRequest: QueryAllSignedUpStudentsWebRequest): ResponseEntity<SignedUpStudentsResponse> {
+        val request = lectureRequestMapper.queryAllSignedUpStudentsWebRequestToDto(webRequest)
+        val response = lectureService.queryAllSignedUpStudents(id, request)
         return ResponseEntity.ok(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllSignedUpStudentsRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllSignedUpStudentsRequest.kt
@@ -1,0 +1,7 @@
+package team.msg.domain.lecture.presentation.data.request
+
+import org.springframework.web.bind.annotation.RequestParam
+
+data class QueryAllSignedUpStudentsRequest(
+    val isComplete: Boolean?
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllSignedUpStudentsWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllSignedUpStudentsWebRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.lecture.presentation.data.web
+
+import org.springframework.web.bind.annotation.RequestParam
+
+data class QueryAllSignedUpStudentsWebRequest(
+    @RequestParam(required = false, name = "is_complete")
+    val isComplete: Boolean?
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -7,6 +7,7 @@ import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequ
 import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllSignedUpStudentsRequest
 import team.msg.domain.lecture.presentation.data.request.UpdateLectureRequest
 import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
@@ -32,7 +33,7 @@ interface LectureService {
     fun cancelSignUpLecture(id: UUID)
     fun queryInstructors(keyword: String): InstructorsResponse
     fun queryAllSignedUpLectures(studentId: UUID): SignedUpLecturesResponse
-    fun queryAllSignedUpStudents(id: UUID): SignedUpStudentsResponse
+    fun queryAllSignedUpStudents(id: UUID, request: QueryAllSignedUpStudentsRequest): SignedUpStudentsResponse
     fun querySignedUpStudentDetails(id: UUID, studentId: UUID): SignedUpStudentDetailsResponse
     fun updateLectureCompleteStatus(id: UUID, studentIds: List<UUID>)
     fun cancelLectureCompleteStatus(id: UUID, studentIds: List<UUID>)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -471,21 +471,20 @@ class LectureServiceImpl(
         val students = when(user.authority){
             Authority.ROLE_TEACHER -> {
                 val teacher = teacherRepository findByUser user
-                registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(id, teacher.club.id)
+                registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(id, teacher.club.id, request.isComplete)
             }
             Authority.ROLE_BBOZZAK -> {
                 val bbozzak = bbozzakRepository findByUser user
-                registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(id, bbozzak.club.id)
+                registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(id, bbozzak.club.id, request.isComplete)
             }
-            Authority.ROLE_ADMIN -> registeredLectureRepository.findSignedUpStudentsByLectureId(id)
+            Authority.ROLE_ADMIN -> registeredLectureRepository.findSignedUpStudentsByLectureId(id, request.isComplete)
             else -> {
                 val lecture = lectureRepository findById id
                 if(lecture.user != user)
                     throw ForbiddenSignedUpLectureException("학생의 수강 이력을 볼 권한이 없습니다. info : [ userId = ${user.id} ]")
-                registeredLectureRepository.findSignedUpStudentsByLectureId(id)
+                registeredLectureRepository.findSignedUpStudentsByLectureId(id, request.isComplete)
             }
         }
-        .filter { request.isComplete == null || it.registeredLecture.isComplete() == request.isComplete }
         .map { LectureResponse.of(it.student, it.registeredLecture.isComplete()) }
 
         val response = LectureResponse.signedUpOf(students)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -461,11 +461,11 @@ class LectureServiceImpl(
      * 뽀짝 선생님, 취업 동아리 선생님 -> 담당 동아리 소속 학생만 조회
      * 어드민 -> 제한 없음
      *
-     * @param 조회할 강의 id
+     * @param 조회할 강의 id, 필터링할 강의 이수 여부
      * @return 조회한 학생 정보를 담은 list dto
      */
     @Transactional(readOnly = true)
-    override fun queryAllSignedUpStudents(id: UUID): SignedUpStudentsResponse {
+    override fun queryAllSignedUpStudents(id: UUID, request: QueryAllSignedUpStudentsRequest): SignedUpStudentsResponse {
         val user = userUtil.queryCurrentUser()
 
         val students = when(user.authority){
@@ -484,7 +484,9 @@ class LectureServiceImpl(
                     throw ForbiddenSignedUpLectureException("학생의 수강 이력을 볼 권한이 없습니다. info : [ userId = ${user.id} ]")
                 registeredLectureRepository.findSignedUpStudentsByLectureId(id)
             }
-        }.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
+        }
+        .filter { request.isComplete == null || it.registeredLecture.idComplete() == request.isComplete }
+        .map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
 
         val response = LectureResponse.signedUpOf(students)
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -485,8 +485,8 @@ class LectureServiceImpl(
                 registeredLectureRepository.findSignedUpStudentsByLectureId(id)
             }
         }
-        .filter { request.isComplete == null || it.registeredLecture.idComplete() == request.isComplete }
-        .map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
+        .filter { request.isComplete == null || it.registeredLecture.isComplete() == request.isComplete }
+        .map { LectureResponse.of(it.student, it.registeredLecture.isComplete()) }
 
         val response = LectureResponse.signedUpOf(students)
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -1240,9 +1240,9 @@ class LectureServiceImplTest : BehaviorSpec({
         every { teacherRepository.findByUser(teacherUser) } returns teacher
         every { bbozzakRepository.findByUser(bbozzakUser) } returns bbozzak
 
-        every { registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(lectureId, clubAId) } returns clubAStudents
-        every { registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(lectureId, clubBId) } returns clubBStudents
-        every { registeredLectureRepository.findSignedUpStudentsByLectureId(lectureId) } returns students
+        every { registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(lectureId, clubAId, request.isComplete) } returns clubAStudents
+        every { registeredLectureRepository.findSignedUpStudentsByLectureIdAndClubId(lectureId, clubBId, request.isComplete) } returns clubBStudents
+        every { registeredLectureRepository.findSignedUpStudentsByLectureId(lectureId, request.isComplete) } returns students
 
         every { lectureRepository.findByIdOrNull(lectureId) } returns lecture
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -36,6 +36,7 @@ import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequ
 import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllSignedUpStudentsRequest
 import team.msg.domain.lecture.presentation.data.request.UpdateLectureRequest
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDateResponse
@@ -1117,6 +1118,10 @@ class LectureServiceImplTest : BehaviorSpec({
         val studentPhoneNumber = "phoneNumber"
         val schoolName = "광주소프트웨어마이스터고등학교"
 
+        val request = fixture<QueryAllSignedUpStudentsRequest> {
+            property(QueryAllSignedUpStudentsRequest::isComplete) { null }
+        }
+
         val studentUserA = fixture<User>{
             property(User::id) { studentUserId }
             property(User::name) { studentName }
@@ -1244,7 +1249,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 Teacher라면"){
             every { userUtil.queryCurrentUser() } returns teacherUser
 
-            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId)
+            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId, request)
             Then("result와 response가 같아야 한다") {
                 result shouldBe clubAStudentsResponse
             }
@@ -1253,7 +1258,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 Bbozzak라면"){
             every { userUtil.queryCurrentUser() } returns bbozzakUser
 
-            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId)
+            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId, request)
             Then("result와 response가 같아야 한다") {
                 result shouldBe clubBStudentsResponse
             }
@@ -1262,7 +1267,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 Admin이라면") {
             every { userUtil.queryCurrentUser() } returns adminUser
 
-            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId)
+            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId, request)
             Then("result와 response가 같아야 한다") {
                 result shouldBe allStudentsResponse
             }
@@ -1271,7 +1276,7 @@ class LectureServiceImplTest : BehaviorSpec({
         When("현재 로그인 한 유저가 PROFESSOR, COMPANY_INSTRUCTOR, GOVERNMENT이고 강의 강사라면") {
             every { userUtil.queryCurrentUser() } returns professorUserA
 
-            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId)
+            val result = lectureServiceImpl.queryAllSignedUpStudents(lectureId, request)
             Then("result와 response가 같아야 한다") {
                 result shouldBe allStudentsResponse
             }
@@ -1282,7 +1287,7 @@ class LectureServiceImplTest : BehaviorSpec({
 
             Then("ForbiddenCompletedLectureException이 발생해야 한다.") {
                 shouldThrow<ForbiddenSignedUpLectureException> {
-                    lectureServiceImpl.queryAllSignedUpStudents(lectureId)
+                    lectureServiceImpl.queryAllSignedUpStudents(lectureId, request)
                 }
             }
         }

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -1229,9 +1229,9 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Lecture::user) { professorUserA }
         }
 
-        val allStudentsData = students.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
-        val clubAStudentsData = clubAStudents.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
-        val clubBStudentsData = clubBStudents.map { LectureResponse.of(it.student, it.registeredLecture.idComplete()) }
+        val allStudentsData = students.map { LectureResponse.of(it.student, it.registeredLecture.isComplete()) }
+        val clubAStudentsData = clubAStudents.map { LectureResponse.of(it.student, it.registeredLecture.isComplete()) }
+        val clubBStudentsData = clubBStudents.map { LectureResponse.of(it.student, it.registeredLecture.isComplete()) }
 
         val allStudentsResponse = LectureResponse.signedUpOf(allStudentsData)
         val clubAStudentsResponse = LectureResponse.signedUpOf(clubAStudentsData)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -31,5 +31,5 @@ class RegisteredLecture(
     val completeStatus: CompleteStatus = CompleteStatus.NOT_COMPLETED_YET
 ) : BaseUUIDEntity(id) {
 
-    fun idComplete() = completeStatus != CompleteStatus.NOT_COMPLETED_YET
+    fun isComplete() = completeStatus != CompleteStatus.NOT_COMPLETED_YET
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
@@ -9,7 +9,7 @@ interface CustomRegisteredLectureRepository {
     fun deleteAllByStudentId(studentId: UUID)
     fun existsOne(studentId: UUID,lectureId: UUID): Boolean
     fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<LectureAndRegisteredProjection>
-    fun findSignedUpStudentsByLectureId(lectureId: UUID): List<SignedUpStudentProjection>
-    fun findSignedUpStudentsByLectureIdAndClubId(lectureId: UUID, clubId: Long): List<SignedUpStudentProjection>
+    fun findSignedUpStudentsByLectureId(lectureId: UUID, isComplete: Boolean?): List<SignedUpStudentProjection>
+    fun findSignedUpStudentsByLectureIdAndClubId(lectureId: UUID, clubId: Long, isComplete: Boolean?): List<SignedUpStudentProjection>
     fun findByLectureIdAndStudentId(lectureId: UUID, studentId: UUID): RegisteredLecture?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
@@ -108,5 +108,5 @@ class CustomRegisteredLectureRepositoryImpl(
         else
             listOf(
                 CompleteStatus.NOT_COMPLETED_YET
-            ).also { println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>.$isComplete<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<") }
+            )
 }


### PR DESCRIPTION
## 💡 배경 및 개요

강의 신청 학생 리스트를 이수 여부에 따라 필터링하여 조회할 수 있도록 변경했습니다.

Resolves: #561 

## 📃 작업내용

- webRequest 추가
- filter 과정 추가

## 🙋‍♂️ 리뷰노트

registeredLecture에서 강의 이수 여부 정보를 가지고 있으나 enum으로 가지고 있어 조회 후 filter 고차함수를 이용해 필터링하는 방향으로 구현했습니다.

query param을 class로 다룬 이유는... 전에 언급했듯이 request 매핑해놓은 곳에 null이 들어온 순간 터져버리기 때문입니다... 

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
