### PR TITLE
🔀 :: Redisson connection 개수 조정

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedissonConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedissonConfig.kt
@@ -21,9 +21,12 @@ class RedissonConfig(
         val config = Config()
         val codec = StringCodec()
         config.codec = codec
-        config.useSingleServer().setAddress(
-            "$REDIS_PREFIX${redisProperties.host}:${redisProperties.port}"
-        )
+        config.useSingleServer()
+            .setAddress(
+                "$REDIS_PREFIX${redisProperties.host}:${redisProperties.port}"
+            )
+            .setConnectionPoolSize(10)
+            .setConnectionMinimumIdleSize(5)
         return Redisson.create(config)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedissonConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedissonConfig.kt
@@ -21,11 +21,12 @@ class RedissonConfig(
         val config = Config()
         val codec = StringCodec()
         config.codec = codec
+
         config.useSingleServer()
             .setAddress(
                 "$REDIS_PREFIX${redisProperties.host}:${redisProperties.port}"
             )
-            .setConnectionPoolSize(10)
+            .setConnectionPoolSize(20)
             .setConnectionMinimumIdleSize(5)
         return Redisson.create(config)
     }


### PR DESCRIPTION
## 💡 배경 및 개요

분산 락에서만 이용하는 redisson client가 필요 이상의 connection을 생성하고 있었습니다

Resolves: #565 

## 📃 작업내용

Redisson max connection 개수 10개로 제한
Redisson min connection 개수 5개로 제한

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
검색을 해본다고 해봤는데 뭔가 적합한 커넥션 개수를 딱히 찾기가 어려워 임의로 설정한 것이니 의견 있으시다면 자유롭게 다이렉트로 내주세요